### PR TITLE
Updated source table API operations to use appropriate HTTP methods

### DIFF
--- a/geoflow-server/src/main/kotlin/html/bootstrap-tables.kt
+++ b/geoflow-server/src/main/kotlin/html/bootstrap-tables.kt
@@ -43,7 +43,7 @@ fun FlowContent.basicTable(
             attributes["data-custom-sort"] = customSortFunction.trim()
         }
         if (tableButtons.isNotEmpty()) {
-            attributes["data-buttons"] = "buttons"
+            attributes["data-buttons"] = "${tableId}buttons"
         }
         thead {
             tr {
@@ -62,7 +62,7 @@ fun FlowContent.basicTable(
             script {
                 unsafe {
                     raw("""
-                        function buttons() {
+                        function ${tableId}buttons() {
                             return {
                                 ${tableButtons.joinToString { it.button }}
                             }
@@ -103,7 +103,7 @@ fun FlowContent.autoRefreshTable(
         attributes["data-thead-classes"] = "thead-dark"
         attributes["data-search"] = "true"
         if (tableButtons.isNotEmpty()) {
-            attributes["data-buttons"] = "buttons"
+            attributes["data-buttons"] = "${tableId}buttons"
         }
         thead {
             tr {
@@ -122,7 +122,7 @@ fun FlowContent.autoRefreshTable(
             script {
                 unsafe {
                     raw("""
-                        function buttons() {
+                        function ${tableId}buttons() {
                             return {
                                 ${tableButtons.joinToString { it.button }}
                             }

--- a/geoflow-server/src/main/resources/javascript/utils.js
+++ b/geoflow-server/src/main/resources/javascript/utils.js
@@ -23,18 +23,38 @@ function postValue(url, func = function(value) {console.log(value)}) {
     fetch(url, options).then(func);
 }
 
+function patchValue(url, func = function(value) {console.log(value)}) {
+    const options = {
+        method: 'PATCH',
+    };
+    fetch(url, options).then(func);
+}
+
+function deleteValue(url, func = function(value) {console.log(value)}) {
+    const options = {
+        method: 'DELETE',
+    };
+    fetch(url, options).then(func);
+}
+
+var requestMethods = {
+    insert: postValue,
+    update: patchValue,
+    delete: deleteValue,
+}
+
 var stOid = 0;
 var sourceTablesTableId = 'source-tables';
 var sourceTableModalId = 'sourceTableData';
-var saveChnagesId = 'saveChanges';
+var saveChangesId = 'saveChanges';
 var deleteRecordId = 'deleteRecord';
 var sourceTableRecordLabelId = 'sourceTableRecordLabel';
 
 function postSourceTableChanges(method) {
     const runId = new URLSearchParams(window.location.href.replace(/^[^?]+/g, '')).get('runId');
     const params = $(`#${sourceTableModalId}EditRowBody`).serialize();
-    postValue(
-        `/api/source-tables?method=${method}&stOid=${stOid}&runId=${runId}&${params}`,
+    requestMethods[method](
+        `/api/source-tables?stOid=${stOid}&runId=${runId}&${params}`,
         function(response) {
             $(`#${sourceTablesTableId}`).bootstrapTable('refresh');
             response.json().then(body => {


### PR DESCRIPTION
Changed API path for working with source table records to handle CRUD operations separately using appropriate HTTP methods (ie update -> patch, post -> insert). This will better handle operations and guide the API user's experience.